### PR TITLE
Add Python 3.13/3.14 CI, drop EOL 3.9, fix Dependabot alerts

### DIFF
--- a/.github/workflows/python-app-3.13.yml
+++ b/.github/workflows/python-app-3.13.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python 3.13 application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.13"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 poetry
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Build with Poetry 
+      run: |
+        poetry build
+    - name: Install with Poetry 
+      run: |
+        poetry install

--- a/.github/workflows/python-app-3.14.yml
+++ b/.github/workflows/python-app-3.14.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python 3.9 application
+name: Python 3.14 application
 
 on:
   push:
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.14
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.14"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,20 @@
 [project]
 name = "amlhpc"
-version = "0.2.3"
+version = "0.2.4"
 description = "Emulate Slurm/PBS/LSF HPC scheduler in Azure ML"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 authors = [
     { name = "Hugo Meiland", email = "hugo.meiland@microsoft.com" },
 ]
 dependencies = [
     "azure-ai-ml>=1.34.0,<2.0.0",
     "azure-identity>=1.17.0,<2.0.0",
-    "requests>=2.31.0,<3.0.0",
+    "requests>=2.33.0,<3.0.0",
+    # Security floors for transitive dependencies (Dependabot high-severity alerts).
+    # These patched releases require Python >=3.10, hence the requires-python bump above.
+    "cryptography>=48.0.1",  # GHSA-537c-gmf6-5ccf (vulnerable OpenSSL in wheels)
+    "urllib3>=2.7.0",        # GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Extends CI to the current Python releases and clears the open Dependabot alerts on `pyproject.toml`.

### CI
- Add `python-app-3.13.yml` and `python-app-3.14.yml`, matching the existing per-version workflow pattern.
- Remove `python-app-3.9.yml`. Net matrix: **3.10, 3.11, 3.12, 3.13, 3.14**.

### Drop Python 3.9
- Python 3.9 is **EOL since October 2025**.
- The patched `urllib3` (>=2.7.0) and `requests` (>=2.33.0) that clear the alerts below **require Python >=3.10**, so 3.9 cannot be secured. `requires-python` is now `>=3.10,<4.0`.

### Security (Dependabot)
| Package | Floor added | Advisory |
|---|---|---|
| cryptography | `>=48.0.1` | GHSA-537c-gmf6-5ccf (High) + lower-severity |
| urllib3 | `>=2.7.0` | GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j (High) |
| requests | `>=2.33.0` (was `>=2.31.0`) | GHSA-gc5v-m9x4-r6x2 (Medium) |

`cryptography` and `urllib3` are transitive (pulled in by the azure SDKs + requests); the floors are documented inline so they are not accidentally removed.

### Verified locally (Python 3.10)
- `poetry check` → All set; flake8 syntax gate → 0; `poetry build` → sdist + wheel `0.2.4`.
- `poetry lock` resolves cleanly: cryptography **49.0.0**, urllib3 **2.7.0**, requests **2.34.2**, azure-identity auto-bumped to **1.25.3** — no conflict.