### PR TITLE
Add `deploy` command: Bicep init deployment + partition creation

### DIFF
--- a/amlhpc/deploy.py
+++ b/amlhpc/deploy.py
@@ -1,0 +1,111 @@
+class mlComputeAuth:
+    def get_token(scopes="my_scope", claims="my_claim", tenant_id="my_tenant"):
+        import requests
+        import os
+        from azure.core.credentials import AccessToken
+        resource = "https://management.azure.com"
+        client_id = os.environ.get("DEFAULT_IDENTITY_CLIENT_ID", None)
+        resp = requests.get(f"{os.environ['MSI_ENDPOINT']}?resource={resource}&clientid={client_id}&api-version=2017-09-01", headers={'Secret': os.environ["MSI_SECRET"]})
+        resp.raise_for_status()
+        my_token = AccessToken(resp.json()["access_token"], int(resp.json()["expires_on"]))
+
+        return my_token
+
+
+def deploy(vargs=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(description='deploy: provision amlhpc infrastructure on Azure Machine Learning')
+    parser.prog = "deploy"
+    subparsers = parser.add_subparsers(dest='subcommand', required=True)
+
+    init_parser = subparsers.add_parser('init', help='deploy the initial amlhpc infrastructure from the Bicep template (workspace, dependencies, login VM and default cluster)')
+    init_parser.add_argument('-g', '--resource-group', required=True, help='resource group to deploy into; created if it does not exist')
+    init_parser.add_argument('-l', '--location', default='westus', help='Azure region for the resource group (default: westus)')
+    init_parser.add_argument('-n', '--name', default='amlhpc', help='deployment name parameter, used as a prefix for the resource names (default: amlhpc)')
+    init_parser.add_argument('-t', '--template', default='deploy/amlhpc_simple.bicep', help='path to the Bicep template (default: deploy/amlhpc_simple.bicep)')
+    init_parser.add_argument('--what-if', action='store_true', help='preview the changes without deploying any resources')
+
+    partition_parser = subparsers.add_parser('partition', help='add a compute partition (AmlCompute cluster) to the workspace')
+    partition_parser.add_argument('-n', '--name', required=True, help='partition (compute cluster) name')
+    partition_parser.add_argument('-s', '--size', default='Standard_F2s_v2', help='VM size (default: Standard_F2s_v2)')
+    partition_parser.add_argument('--min-nodes', default=0, type=int, help='minimum number of nodes to keep allocated (default: 0)')
+    partition_parser.add_argument('--max-nodes', default=4, type=int, help='maximum number of nodes to scale up to (default: 4)')
+    partition_parser.add_argument('--idle-time', default=120, type=int, help='seconds a node stays idle before scaling down (default: 120)')
+    partition_parser.add_argument('--priority', default='Dedicated', choices=['Dedicated', 'LowPriority'], help='VM priority tier (default: Dedicated)')
+
+    args = parser.parse_args(vargs)
+
+    if args.subcommand == 'init':
+        deploy_init(args)
+    elif args.subcommand == 'partition':
+        deploy_partition(args)
+
+
+def deploy_init(args):
+    import os
+    import shutil
+    import subprocess
+
+    if shutil.which('az') is None:
+        print("deploy init requires the Azure CLI (az); install it or deploy the Bicep template manually (see deploy/README.md)")
+        exit(-1)
+
+    if not os.path.isfile(args.template):
+        print("Missing: Bicep template '" + args.template + "' not found; run from a checkout or set --template")
+        exit(-1)
+
+    subprocess.run(["az", "group", "create", "--name", args.resource_group, "--location", args.location], check=True)
+
+    deploy_command = ["az", "deployment", "group", "create",
+                      "--resource-group", args.resource_group,
+                      "--template-file", args.template,
+                      "--parameters", "name=" + args.name]
+    if args.what_if:
+        deploy_command.append("--what-if")
+    subprocess.run(deploy_command, check=True)
+
+
+def deploy_partition(args):
+    import os
+
+    try:
+        subscription_id = os.environ['SUBSCRIPTION']
+        resource_group = os.environ['CI_RESOURCE_GROUP']
+        workspace_name = os.environ['CI_WORKSPACE']
+    except Exception as error:
+        print("please set the export variables: SUBSCRIPTION, CI_RESOURCE_GROUP and CI_WORKSPACE")
+        exit(-1)
+
+    from azure.ai.ml import MLClient
+    from azure.identity import DefaultAzureCredential
+    from azure.ai.ml.entities import AmlCompute
+
+    import logging
+    logging.getLogger('azure.ai.ml._utils').setLevel(logging.CRITICAL)
+
+    try:
+        on_aml = os.environ['APPSETTING_WEBSITE_SITE_NAME']
+        if (on_aml == 'AMLComputeInstance'):
+            credential = mlComputeAuth()
+    except:
+        credential = DefaultAzureCredential()
+
+    ml_client = MLClient(
+        credential=credential,
+        subscription_id=subscription_id,
+        resource_group_name=resource_group,
+        workspace_name=workspace_name,
+        enable_telemetry=False,
+        )
+
+    partition = AmlCompute(
+        name=args.name,
+        size=args.size,
+        min_instances=args.min_nodes,
+        max_instances=args.max_nodes,
+        idle_time_before_scale_down=args.idle_time,
+        tier=args.priority,
+        )
+    returned_partition = ml_client.compute.begin_create_or_update(partition).result()
+    print(returned_partition.name + "\t" + returned_partition.size + "\t" + str(returned_partition.max_instances))

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,11 +1,32 @@
+# deploy
 
-Deployment steps of AML HPC cluster:
+Deploy amlhpc infrastructure on Azure Machine Learning.
 
+## Using the `deploy` command (amlhpc)
+
+Initial deployment — workspace, dependencies, container registry, network, a login VM
+and a default cluster (run from a checkout so the Bicep template is found):
+
+```bash
+deploy init -g amlhpc -l "centralus" -n amlhpc
+deploy init -g amlhpc --what-if            # preview only, creates nothing
 ```
+
+Add a compute partition (AmlCompute cluster = Slurm partition) to an existing workspace.
+Requires `SUBSCRIPTION`, `CI_RESOURCE_GROUP` and `CI_WORKSPACE` to be set:
+
+```bash
+deploy partition -n f4s -s Standard_F4s_v2 --max-nodes 5
+deploy partition -n hb --size Standard_HB120rs_v3 --min-nodes 0 --max-nodes 8 --priority LowPriority
+```
+
+## Manual deployment (az CLI)
+
+```bash
 az group create --name amlhpc --location "Central US"
 az deployment group create \
 	--resource-group amlhpc \
-   	--template-file amlhpc_simple.bicep \
+	--template-file amlhpc_simple.bicep \
 	--parameters name=amlhpc
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amlhpc"
-version = "0.4.0"
+version = "0.5.0"
 description = "Emulate Slurm/PBS/LSF HPC scheduler in Azure ML"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
@@ -26,6 +26,7 @@ sbatch = "amlhpc.slurm.sbatch:sbatch"
 sinfo = "amlhpc.slurm.sinfo:sinfo"
 squeue = "amlhpc.slurm.squeue:squeue"
 container = "amlhpc.container:container"
+deploy = "amlhpc.deploy:deploy"
 
 [tool.poetry]
 packages = [


### PR DESCRIPTION
## Summary
New `deploy` console command to provision amlhpc infrastructure on Azure ML, with two subcommands.

### `deploy init` — Bicep initial deployment
Deploys `deploy/amlhpc_simple.bicep` (workspace, dependencies, ACR, network, login VM, default cluster) via `az deployment group create` — which compiles the Bicep directly, matching `deploy/README.md`.
```bash
deploy init -g amlhpc -l centralus -n amlhpc
deploy init -g amlhpc --what-if       # no-op preview
```
- Creates the resource group if needed; `--template` overrides the Bicep path (defaults to `deploy/amlhpc_simple.bicep`, so run from a checkout).
- Uses `az` (matches the documented flow + compiles Bicep); no new Python dependency.

### `deploy partition` — add a compute partition
Adds an AmlCompute cluster (a Slurm partition) to the workspace via `MLClient` + `AmlCompute` — same `SUBSCRIPTION`/`CI_RESOURCE_GROUP`/`CI_WORKSPACE` + `DefaultAzureCredential` pattern as `sinfo`/`container`.
```bash
deploy partition -n f4s -s Standard_F4s_v2 --max-nodes 5
deploy partition -n hb --size Standard_HB120rs_v3 --max-nodes 8 --priority LowPriority
```
Options: `--name --size --min-nodes --max-nodes --idle-time --priority`.

### Verification (live, `grid-ai-ws`)
- `deploy partition -n f4s -s Standard_F4s_v2 --max-nodes 3` created the cluster; it now appears in `sinfo` next to `f2s`.
- `deploy init --what-if` validated the Bicep: *Resource changes: 13 to create, 7 to ignore* (nothing deployed).
- Local: flake8 syntax gate 0, `poetry check` OK, `poetry build` → `0.5.0`; wheel exposes the `deploy` entry point.

Version → **0.5.0**.