### PR TITLE
Fix Bicep CVMFS/EESSI install + default env (match PR #9)

### DIFF
--- a/deploy/amlhpc_simple.bicep
+++ b/deploy/amlhpc_simple.bicep
@@ -138,14 +138,14 @@ resource subnetanf 'Microsoft.Network/virtualNetworks/subnets@2021-08-01' = {
 
 var setupscript_1 = '''
 pip install amlhpc 
-wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb && dpkg -i cvmfs-release-latest_all.deb
+wget https://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb && dpkg -i cvmfs-release-latest_all.deb
 apt-get update && apt-get install -y cvmfs
-wget https://github.com/EESSI/filesystem-layer/releases/download/v0.5.0/cvmfs-config-eessi_0.5.0_all.deb && dpkg -i cvmfs-config-eessi_0.5.0_all.deb
+wget https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb && dpkg -i cvmfs-config-eessi_latest_all.deb
 echo 'CVMFS_CLIENT_PROFILE="single"' > /etc/cvmfs/default.local
 echo 'CVMFS_QUOTA_LIMIT=10000' >> /etc/cvmfs/default.local
-echo 'CVMFS_REPOSITORIES=cms.cern.ch,pilot.eessi-hpc.org,software.eessi.io' >> /etc/cvmfs/default.local
+echo 'CVMFS_REPOSITORIES=cms.cern.ch,software.eessi.io' >> /etc/cvmfs/default.local
 echo 'CVMFS_HTTP_PROXY=DIRECT' >> /etc/cvmfs/default.local
-cvmfs_config setup; mkdir -p /cvmfs/pilot.eessi-hpc.org /cvmfs/software.eessi.io
+cvmfs_config setup; mkdir -p /cvmfs/software.eessi.io
 echo "export SUBSCRIPTION='''
 var setupscript_2 = concat(setupscript_1, subscription().subscriptionId)
 var setupscript = concat(setupscript_2, '" > /etc/profile.d/amlhpc.sh')
@@ -230,10 +230,10 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource ml_cust_env 'Microsoft.MachineLearningServices/workspaces/environments/versions@2023-06-01-preview' = {  
-  name: '${workspace.name}/amlhpc-ubuntu2004/1'  
+  name: '${workspace.name}/amlhpc-ubuntu2204/1'  
   properties: {  
     osType: 'Linux'
-    image: 'docker.io/hmeiland/amlhpc-ubuntu2004'
+    image: 'docker.io/hmeiland/amlhpc-ubuntu2204'
     autoRebuild: 'OnBaseImageUpdate'
   }  
 }  

--- a/deploy/amlhpc_simple.json
+++ b/deploy/amlhpc_simple.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "15994311308947372117"
+      "version": "0.45.15.27210",
+      "templateHash": "10205829648842811525"
     }
   },
   "parameters": {
@@ -32,7 +32,7 @@
     "applicationInsightId": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]",
     "containerRegistryId": "[resourceId('Microsoft.ContainerRegistry/registries', variables('containerRegistryName'))]",
     "subnetClusterId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), 'cluster')]",
-    "setupscript_1": "pip install amlhpc \nwget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb && dpkg -i cvmfs-release-latest_all.deb\napt-get update && apt-get install -y cvmfs\nwget https://github.com/EESSI/filesystem-layer/releases/download/v0.5.0/cvmfs-config-eessi_0.5.0_all.deb && dpkg -i cvmfs-config-eessi_0.5.0_all.deb\necho 'CVMFS_CLIENT_PROFILE=\"single\"' > /etc/cvmfs/default.local\necho 'CVMFS_QUOTA_LIMIT=10000' >> /etc/cvmfs/default.local\necho 'CVMFS_REPOSITORIES=cms.cern.ch,pilot.eessi-hpc.org,software.eessi.io' >> /etc/cvmfs/default.local\necho 'CVMFS_HTTP_PROXY=DIRECT' >> /etc/cvmfs/default.local\ncvmfs_config setup; mkdir -p /cvmfs/pilot.eessi-hpc.org /cvmfs/software.eessi.io\necho \"export SUBSCRIPTION=",
+    "setupscript_1": "pip install amlhpc \nwget https://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb && dpkg -i cvmfs-release-latest_all.deb\napt-get update && apt-get install -y cvmfs\nwget https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb && dpkg -i cvmfs-config-eessi_latest_all.deb\necho 'CVMFS_CLIENT_PROFILE=\"single\"' > /etc/cvmfs/default.local\necho 'CVMFS_QUOTA_LIMIT=10000' >> /etc/cvmfs/default.local\necho 'CVMFS_REPOSITORIES=cms.cern.ch,software.eessi.io' >> /etc/cvmfs/default.local\necho 'CVMFS_HTTP_PROXY=DIRECT' >> /etc/cvmfs/default.local\ncvmfs_config setup; mkdir -p /cvmfs/software.eessi.io\necho \"export SUBSCRIPTION=",
     "setupscript_2": "[concat(variables('setupscript_1'), subscription().subscriptionId)]",
     "setupscript": "[concat(variables('setupscript_2'), '\" > /etc/profile.d/amlhpc.sh')]"
   },
@@ -267,10 +267,10 @@
     {
       "type": "Microsoft.MachineLearningServices/workspaces/environments/versions",
       "apiVersion": "2023-06-01-preview",
-      "name": "[format('{0}/amlhpc-ubuntu2004/1', variables('workspaceName'))]",
+      "name": "[format('{0}/amlhpc-ubuntu2204/1', variables('workspaceName'))]",
       "properties": {
         "osType": "Linux",
-        "image": "docker.io/hmeiland/amlhpc-ubuntu2004",
+        "image": "docker.io/hmeiland/amlhpc-ubuntu2204",
         "autoRebuild": "OnBaseImageUpdate"
       },
       "dependsOn": [


### PR DESCRIPTION
## Summary
Follow-up to #9/#10: the `deploy/amlhpc_simple.bicep` used by `deploy init` still had the stale bits PR #9 fixed in the Dockerfiles.

### Login-VM setup script
- CVMFS repo: `ecsft.cern.ch` → **`cvmrepo.s3.cern.ch`** (CERN's current repo, correct signing key — see EESSI/docs#652).
- `cvmfs-config-eessi` **v0.5.0 → latest**.
- Dropped the deprecated **`pilot.eessi-hpc.org`** from `CVMFS_REPOSITORIES` and the `mkdir`.

### Custom environment
- `amlhpc-ubuntu2004` → **`amlhpc-ubuntu2204`** (name + `docker.io/hmeiland/amlhpc-ubuntu2204` image; verified that image exists on Docker Hub).

### Kept in sync
- Recompiled `amlhpc_simple.json` from the updated Bicep (`az bicep build`) — it backs the Deploy-to-Azure button.

### Verification
- `az bicep build` OK.
- `deploy init --what-if` shows the custom env as `amlhpc-ubuntu2204` with image `docker.io/hmeiland/amlhpc-ubuntu2204`: *Resource changes: 13 to create, 7 to ignore* (nothing deployed).

No version bump: only the Bicep/ARM template changed; the pip package is unchanged.